### PR TITLE
Handel response result

### DIFF
--- a/src/Contracts/Models/ResultContract.php
+++ b/src/Contracts/Models/ResultContract.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DeepseekPhp\Contracts\Models;
+
+
+interface ResultContract
+{
+    /**
+     * result status code 
+     * @return int
+     */
+    public function getStatusCode(): int;
+
+    /**
+     * result content date as a string
+     * @return string
+     */
+    public function getContent(): string;
+
+    /**
+     * if response status code is ok (200)
+     * @return bool
+     */
+    public function isSuccess(): bool;
+}

--- a/src/DeepseekClient.php
+++ b/src/DeepseekClient.php
@@ -3,6 +3,7 @@
 namespace DeepseekPhp;
 
 use DeepseekPhp\Contracts\DeepseekClientContract;
+use DeepseekPhp\Contracts\Models\ResultContract;
 use DeepseekPhp\Enums\Queries\QueryRoles;
 use DeepseekPhp\Enums\Requests\HeaderFlags;
 use DeepseekPhp\Enums\Requests\QueryFlags;
@@ -46,6 +47,12 @@ class DeepseekClient implements DeepseekClientContract
     protected float $temperature;
 
     /**
+     * response result contract
+     * @var ResultContract
+     */
+    protected ResultContract $result;
+
+    /**
      * Initialize the DeepseekClient with a PSR-compliant HTTP client.
      *
      * @param ClientInterface $httpClient The HTTP client used for making API requests.
@@ -67,7 +74,8 @@ class DeepseekClient implements DeepseekClientContract
         ];
         // Clear queries after sending
         $this->queries = [];
-        return (new Resource($this->httpClient))->sendRequest($requestData);
+        $this->result = (new Resource($this->httpClient))->sendRequest($requestData);
+        return $this->getResult()->getContent();
     }
 
     /**
@@ -140,4 +148,12 @@ class DeepseekClient implements DeepseekClientContract
         ];
     }
 
+    /**
+     * response result model
+     * @return \DeepseekPhp\Contracts\Models\ResultContract
+     */
+    public function getResult(): ResultContract
+    {
+        return $this->result;
+    }
 }

--- a/src/Enums/Requests/HTTPState.php
+++ b/src/Enums/Requests/HTTPState.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DeepseekPhp\Enums\Requests;
+
+enum HTTPState: int
+{
+    /**
+     * HTTP successful response
+     * status is ok
+     */
+    case OK = 200;
+
+    /**
+     * HTTP client error response
+     * status is unauthorized
+     */
+    case UNAUTHORIZED = 401;
+
+    /**
+     * HTTP client error response
+     * status is payment required
+     */
+    case PAYMENT_REQUIRED = 402;
+
+}

--- a/src/Models/BadResult.php
+++ b/src/Models/BadResult.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DeepseekPhp\Models;
+
+
+class BadResult extends ResultAbstract
+{
+    
+}
+

--- a/src/Models/FailureResult.php
+++ b/src/Models/FailureResult.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DeepseekPhp\Models;
+
+
+class FailureResult extends ResultAbstract 
+{
+
+}
+

--- a/src/Models/ResultAbstract.php
+++ b/src/Models/ResultAbstract.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DeepseekPhp\Models;
+
+
+use DeepseekPhp\Contracts\Models\ResultContract;
+use DeepseekPhp\Enums\Requests\HTTPState;
+use Psr\Http\Message\ResponseInterface;
+
+abstract class ResultAbstract implements ResultContract
+{
+    protected ?int $statusCode;
+    protected ?string $content;
+    /**
+     * handel response comeing from request
+     * @var ResponseInterface|null
+     */
+    protected ?ResponseInterface $response;
+    public function __construct(?int $statusCode = null, ?string $content = null)
+    {
+        $this->statusCode = $statusCode;
+        $this->content = $content;
+    }
+    protected function setStatusCode(int $statusCode)
+    {
+        $this->statusCode = $statusCode;
+        return $this;
+    }
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+    protected function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+    public function setResponse(ResponseInterface $response): static
+    {
+        $this->response = $response;
+        $this->setStatusCode($this->getResponse()->getStatusCode());
+        $this->setContent($this->getResponse()->getBody()->getContents());
+        return $this;
+    }
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+    public function isSuccess(): bool
+    {
+        return ($this->getStatusCode() === HTTPState::OK->value);
+    }
+}
+

--- a/src/Models/SuccessResult.php
+++ b/src/Models/SuccessResult.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DeepseekPhp\Models;
+
+
+class SuccessResult extends ResultAbstract
+{
+    
+}
+

--- a/tests/HandelResultDeepseekTest.php
+++ b/tests/HandelResultDeepseekTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace DeepseekPhp\Tests;
+
+
+use DeepseekPhp\Enums\Requests\HTTPState;
+use PHPUnit\Framework\TestCase;
+use DeepseekPhp\DeepseekClient;
+
+class HandelResultDeepseekTest extends TestCase
+{
+    protected $apiKey;
+    protected $expiredApiKey;
+    protected function setUp():void
+    {
+        $this->apiKey = "valid-api-key";
+        $this->expiredApiKey = "expired-api-key";
+    }
+    public function test_ok_response()
+    {
+        $deepseek = DeepseekClient::build($this->apiKey)
+            ->query('Hello Deepseek, how are you today?')
+            ->setTemperature(1.5);
+        $response = $deepseek->run();
+        $result = $deepseek->getResult();
+
+        $this->assertNotEmpty($response);
+        $this->assertEquals(HTTPState::OK->value, $result->getStatusCode());
+    }
+    public function test_can_not_access_with_api_expired_payment()
+    {
+        $deepseek = DeepseekClient::build($this->expiredApiKey)
+            ->query('Hello Deepseek, how are you today?')
+            ->setTemperature(1.5);
+        $response = $deepseek->run();
+        $result = $deepseek->getResult();
+
+        $this->assertNotEmpty($response);
+        if(!$result->isSuccess())
+        {
+            $this->assertEquals(HTTPState::PAYMENT_REQUIRED->value, $result->getStatusCode());
+        }
+    }
+    public function test_access_with_wrong_api_key()
+    {
+        $deepseek = DeepseekClient::build($this->apiKey."wrong-api-key")
+            ->query('Hello Deepseek, how are you today?')
+            ->setTemperature(1.5);
+        $response = $deepseek->run();
+        $result = $deepseek->getResult();
+        
+        $this->assertNotEmpty($response);
+        $this->assertEquals(HTTPState::UNAUTHORIZED->value, $result->getStatusCode());
+    }
+}


### PR DESCRIPTION
Hello
Hope you are well

I have an update regarding catching responses and errors.

### **Problem**
When sending the request, the passed key may be wrong or expired as happened to me, as I use a free account and cannot currently pay to try the API, so I noticed the problem which is the lack of a distinct pattern for exporting the outputs in a uniform manner, as the current coding only outputs the correct response and in the absence of the correct response throws an operation error.

### **Solution**
I created models to receive the different types of responses and all of them use one interface (`ResultContract`) and abstract class or main model (`ResultAbstract`) , the initial models that control the output are:-
- The model `SuccessResult` to receive the response in the case of a success response.
- The model `BadResult` to receive the response in the case of an error in the passed data.
- The model `FailureResult` to receive the response in the case of failure.
All models have the same interface and methods, but in the future each model can be developed according to the use.

**Basic functions**
All models contain uniform functions and they are in the basic model.
The basic is used when fetching the result
- `getStatusCode(): int` to fetch the result status code.
- `getContent(): string` to fetch the result in string format.
- `isSuccess(): bool` to check whether the result is correct or no.

**Secondary is used in specific cases**
- `setResponse(ResponseInterface $response): static` to pass the response (used to catch success & bad responses).

### **Features Of Models**
1. Helps in testing responses.
2. Helps in organizing the code and making it easier to read.
3. The models are unified and each model can control it's properties and methods.