### PR TITLE
wip: update setTemperature method to accept enum instance

### DIFF
--- a/src/DeepseekClient.php
+++ b/src/DeepseekClient.php
@@ -136,9 +136,9 @@ class DeepseekClient implements DeepseekClientContract
         return $this;
     }
 
-    public function setTemperature(float $temperature): self
+    public function setTemperature(TemperatureValues $temperature): self
     {
-        $this->temperature = $temperature;
+        $this->temperature = (float) $temperature->value;
         return $this;
     }
 


### PR DESCRIPTION
This is a small enhancement to accept enum instance within the setTemperature() method, so no redundant values can be passed.

`public function setTemperature(TemperatureValues $temperature): self
    {
        $this->temperature = (float) $temperature->value;
        return $this;
    }`