### PR TITLE
Change namespace to DeepSeekPhp

### DIFF
--- a/src/Contracts/DeepseekClientContract.php
+++ b/src/Contracts/DeepseekClientContract.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepseekPhp\Contracts;
+namespace DeepSeekPhp\Contracts;
 
-use DeepseekPhp\DeepseekClient;
+use DeepSeekPhp\DeepseekClient;
 
 interface DeepseekClientContract
 {

--- a/src/Contracts/Factories/ApiFactoryContract.php
+++ b/src/Contracts/Factories/ApiFactoryContract.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepseekPhp\Contracts\Factories;
+namespace DeepSeekPhp\Contracts\Factories;
 
-use DeepseekPhp\Factories\ApiFactory;
+use DeepSeekPhp\Factories\ApiFactory;
 use GuzzleHttp\Client;
 
 interface ApiFactoryContract

--- a/src/Contracts/Models/ResultContract.php
+++ b/src/Contracts/Models/ResultContract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Contracts\Models;
+namespace DeepSeekPhp\Contracts\Models;
 
 
 interface ResultContract

--- a/src/Contracts/Resources/ResourceContract.php
+++ b/src/Contracts/Resources/ResourceContract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Contracts\Resources;
+namespace DeepSeekPhp\Contracts\Resources;
 
 /**
  * Interface for defining the structure of resource classes.

--- a/src/DeepseekClient.php
+++ b/src/DeepseekClient.php
@@ -2,16 +2,16 @@
 
 namespace DeepseekPhp;
 
-use DeepseekPhp\Contracts\DeepseekClientContract;
-use DeepseekPhp\Contracts\Models\ResultContract;
-use DeepseekPhp\Resources\Resource;
+use DeepSeekPhp\Contracts\DeepseekClientContract;
+use DeepSeekPhp\Contracts\Models\ResultContract;
+use DeepSeekPhp\Resources\Resource;
 use Psr\Http\Client\ClientInterface;
-use DeepseekPhp\Factories\ApiFactory;
-use DeepseekPhp\Enums\Queries\QueryRoles;
-use DeepseekPhp\Enums\Requests\QueryFlags;
-use DeepseekPhp\Enums\Requests\HeaderFlags;
-use DeepseekPhp\Enums\Configs\TemperatureValues;
-use DeepseekPhp\Traits\Resources\{HasChat, HasCoder};
+use DeepSeekPhp\Factories\ApiFactory;
+use DeepSeekPhp\Enums\Queries\QueryRoles;
+use DeepSeekPhp\Enums\Requests\QueryFlags;
+use DeepSeekPhp\Enums\Requests\HeaderFlags;
+use DeepSeekPhp\Enums\Configs\TemperatureValues;
+use DeepSeekPhp\Traits\Resources\{HasChat, HasCoder};
 
 class DeepseekClient implements DeepseekClientContract
 {

--- a/src/Enums/Configs/DefaultConfigs.php
+++ b/src/Enums/Configs/DefaultConfigs.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Configs;
+namespace DeepSeekPhp\Enums\Configs;
 
 enum DefaultConfigs: string
 {

--- a/src/Enums/Configs/TemperatureValues.php
+++ b/src/Enums/Configs/TemperatureValues.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Configs;
+namespace DeepSeekPhp\Enums\Configs;
 
 enum TemperatureValues: string
 {

--- a/src/Enums/Data/DataTypes.php
+++ b/src/Enums/Data/DataTypes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Data;
+namespace DeepSeekPhp\Enums\Data;
 
 enum DataTypes: string
 {

--- a/src/Enums/Queries/QueryRoles.php
+++ b/src/Enums/Queries/QueryRoles.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Queries;
+namespace DeepSeekPhp\Enums\Queries;
 
 enum QueryRoles: string
 {

--- a/src/Enums/Requests/EndpointSuffixes.php
+++ b/src/Enums/Requests/EndpointSuffixes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Requests;
+namespace DeepSeekPhp\Enums\Requests;
 
 enum EndpointSuffixes: string
 {

--- a/src/Enums/Requests/HTTPState.php
+++ b/src/Enums/Requests/HTTPState.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Requests;
+namespace DeepSeekPhp\Enums\Requests;
 
 enum HTTPState: int
 {

--- a/src/Enums/Requests/HeaderFlags.php
+++ b/src/Enums/Requests/HeaderFlags.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Requests;
+namespace DeepSeekPhp\Enums\Requests;
 
 enum HeaderFlags: string
 {

--- a/src/Enums/Requests/QueryFlags.php
+++ b/src/Enums/Requests/QueryFlags.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Enums\Requests;
+namespace DeepSeekPhp\Enums\Requests;
 
 enum QueryFlags: string
 {

--- a/src/Factories/ApiFactory.php
+++ b/src/Factories/ApiFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepseekPhp\Factories;
+namespace DeepSeekPhp\Factories;
 
-use DeepseekPhp\Contracts\Factories\ApiFactoryContract;
-use DeepseekPhp\Enums\Configs\DefaultConfigs;
-use DeepseekPhp\Enums\Requests\HeaderFlags;
+use DeepSeekPhp\Contracts\Factories\ApiFactoryContract;
+use DeepSeekPhp\Enums\Configs\DefaultConfigs;
+use DeepSeekPhp\Enums\Requests\HeaderFlags;
 use GuzzleHttp\Client;
 
 final class ApiFactory implements ApiFactoryContract

--- a/src/Models/BadResult.php
+++ b/src/Models/BadResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Models;
+namespace DeepSeekPhp\Models;
 
 
 class BadResult extends ResultAbstract

--- a/src/Models/FailureResult.php
+++ b/src/Models/FailureResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Models;
+namespace DeepSeekPhp\Models;
 
 
 class FailureResult extends ResultAbstract 

--- a/src/Models/ResultAbstract.php
+++ b/src/Models/ResultAbstract.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Models;
+namespace DeepSeekPhp\Models;
 
 
-use DeepseekPhp\Contracts\Models\ResultContract;
-use DeepseekPhp\Enums\Requests\HTTPState;
+use DeepSeekPhp\Contracts\Models\ResultContract;
+use DeepSeekPhp\Enums\Requests\HTTPState;
 use Psr\Http\Message\ResponseInterface;
 
 abstract class ResultAbstract implements ResultContract

--- a/src/Models/SuccessResult.php
+++ b/src/Models/SuccessResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Models;
+namespace DeepSeekPhp\Models;
 
 
 class SuccessResult extends ResultAbstract

--- a/src/Resources/Chat.php
+++ b/src/Resources/Chat.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Resources;
+namespace DeepSeekPhp\Resources;
 
 class Chat extends Resource
 {

--- a/src/Resources/Coder.php
+++ b/src/Resources/Coder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Resources;
+namespace DeepSeekPhp\Resources;
 
-use DeepseekPhp\Enums\Models;
+use DeepSeekPhp\Enums\Models;
 
 class Coder extends Resource
 {

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DeepseekPhp\Resources;
+namespace DeepSeekPhp\Resources;
 
 use DeepseekPhp\Contracts\Models\ResultContract;
 use DeepseekPhp\Contracts\Resources\ResourceContract;

--- a/src/Traits/Queries/HasQueryParams.php
+++ b/src/Traits/Queries/HasQueryParams.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepseekPhp\Traits\Queries;
+namespace DeepSeekPhp\Traits\Queries;
 
 use DeepseekPhp\Enums\Data\DataTypes;
 use DeepseekPhp\Enums\Requests\QueryFlags;

--- a/src/Traits/Resources/HasChat.php
+++ b/src/Traits/Resources/HasChat.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepseekPhp\Traits\Resources;
+namespace DeepSeekPhp\Traits\Resources;
 
-use DeepseekPhp\Resources\Chat;
+use DeepSeekPhp\Resources\Chat;
 
 trait HasChat
 {

--- a/src/Traits/Resources/HasCoder.php
+++ b/src/Traits/Resources/HasCoder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepseekPhp\Traits\Resources;
+namespace DeepSeekPhp\Traits\Resources;
 
-use DeepseekPhp\Resources\Coder;
+use DeepSeekPhp\Resources\Coder;
 
 trait HasCoder
 {

--- a/tests/DeepseekTest.php
+++ b/tests/DeepseekTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use DeepseekPhp\DeepseekClient;
+use DeepSeekPhp\DeepseekClient;
 
 class DeepseekTest extends TestCase
 {

--- a/tests/HandelResultDeepseekTest.php
+++ b/tests/HandelResultDeepseekTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace DeepseekPhp\Tests;
+namespace DeepSeekPhp\Tests;
 
 
-use DeepseekPhp\Enums\Requests\HTTPState;
+use DeepSeekPhp\Enums\Requests\HTTPState;
 use PHPUnit\Framework\TestCase;
-use DeepseekPhp\DeepseekClient;
+use DeepSeekPhp\DeepseekClient;
 
 class HandelResultDeepseekTest extends TestCase
 {


### PR DESCRIPTION
According to https://www.deepseek.com/ & https://en.wikipedia.org/wiki/DeepSeek we should use `DeepSeek` instead of `Deepseek`

Much better to use `DeepSeek` as namespace instead of `DeepseekPhp`