### PR TITLE
Fix handle response result

### DIFF
--- a/src/DeepseekClient.php
+++ b/src/DeepseekClient.php
@@ -76,7 +76,7 @@ class DeepseekClient implements DeepseekClientContract
         ];
         // Clear queries after sending
         $this->queries = [];
-        $this->result = (new Resource($this->httpClient))->sendRequest($requestData);
+        $this->setResult((new Resource($this->httpClient))->sendRequest($requestData));
         return $this->getResult()->getContent();
     }
 
@@ -148,6 +148,17 @@ class DeepseekClient implements DeepseekClientContract
             'role' => $role ?: QueryRoles::USER->value,
             'content' => $content
         ];
+    }
+
+    /**
+     * set result model
+     * @param \DeepseekPhp\Contracts\Models\ResultContract $result
+     * @return self The current instance for method chaining.
+     */
+    public function setResult(ResultContract $result)
+    {
+        $this->result = $result;
+        return $this;
     }
 
     /**

--- a/src/Traits/Resources/HasChat.php
+++ b/src/Traits/Resources/HasChat.php
@@ -19,6 +19,7 @@ trait HasChat
             'stream' => $this->stream,
         ];
         $this->queries = [];
-        return (new Chat($this->httpClient))->sendRequest($requestData);
+        $this->setResult((new Chat($this->httpClient))->sendRequest($requestData));
+        return $this->getResult()->getContent();
     }
 }

--- a/src/Traits/Resources/HasCoder.php
+++ b/src/Traits/Resources/HasCoder.php
@@ -19,6 +19,7 @@ trait HasCoder
             'stream' => $this->stream,
         ];
         $this->queries = [];
-        return (new Coder($this->httpClient))->sendRequest($requestData);
+        $this->setResult((new Coder($this->httpClient))->sendRequest($requestData));
+        return $this->getResult()->getContent();
     }
 }


### PR DESCRIPTION
Hello
Hope you are well

fix error.

### **Problem**
Output of function `sendRequest()` is not string type.

### **Solution**
Add function `setResult` to assign the result and access it from anywhere.
Add `setResult` solution to:
- function `run()` in `DeepseekClient` class.
- function `code()` in `HasCoder` trait.
- function `chat()` in `HasChat` trait.